### PR TITLE
Fixed compatibility with macOS 10.13 SDK.

### DIFF
--- a/Sparkle.pch
+++ b/Sparkle.pch
@@ -6,18 +6,6 @@
 //  Copyright 2008 Andy Matuschak. All rights reserved.
 //
 
-#ifndef NSAppKitVersionNumber10_4
-#define NSAppKitVersionNumber10_4 824
-#endif
-
-#ifndef NSAppKitVersionNumber10_5
-#define NSAppKitVersionNumber10_5 949
-#endif 
-
-#ifndef NSAppKitVersionNumber10_6
-#define NSAppKitVersionNumber10_6 1038
-#endif 
-
 #ifdef __OBJC__
 
 #define SPARKLE_BUNDLE [NSBundle bundleWithIdentifier:@"org.andymatuschak.Sparkle"]
@@ -26,5 +14,17 @@
 
 #import <Cocoa/Cocoa.h>
 #import "SUConstants.h"
+
+#ifndef NSAppKitVersionNumber10_4
+#define NSAppKitVersionNumber10_4 824
+#endif
+
+#ifndef NSAppKitVersionNumber10_5
+#define NSAppKitVersionNumber10_5 949
+#endif
+
+#ifndef NSAppKitVersionNumber10_6
+#define NSAppKitVersionNumber10_6 1038
+#endif
 
 #endif


### PR DESCRIPTION
Moved NSAppKitVersionNumber constants definition after Cocoa.h header inclusion to avoid compile error with macOS 10.13 SDK. This is caused by NSAppKitVersionNumber constants are now variables rather than macros.